### PR TITLE
Append old LD_PRELOAD when modifying it

### DIFF
--- a/checkrt.c
+++ b/checkrt.c
@@ -103,8 +103,10 @@ void checkrt(char *usr_in_appdir)
         bundle_gcc = 1;
 
     if (bundle_cxx == 1 || bundle_gcc == 1) {
-        optional_ld_preload = malloc(strlen(EXEC_SO) + 13 + len);
-        sprintf(optional_ld_preload, "LD_PRELOAD=%s/" EXEC_SO, usr_in_appdir);
+        char *old_ld_preload = getenv("LD_PRELOAD");
+        optional_ld_preload = malloc(strlen(EXEC_SO) + (old_ld_preload ? 1+strlen(old_ld_preload) : 0) + 13 + len);
+        sprintf(optional_ld_preload, "LD_PRELOAD=%s/" EXEC_SO "%s%s", usr_in_appdir,
+                old_ld_preload ? ":" : "", old_ld_preload ? old_ld_preload : "");
     }
 
     if (bundle_cxx == 1 && bundle_gcc == 0) {


### PR DESCRIPTION
The same way we are appending old `PATH` and `LD_LIBRARY_PATH` when modifying them, I think we should do the same with `LD_PRELOAD` since it can actually contain several libraries. I know it's rarely used with several libs, but who knows what users may intend to do when running an AppImage ;)

Related to https://github.com/darealshinji/AppImageKit-checkrt/issues/4
  