### PR TITLE
Print debug logs when APPIMAGE_CHECKRT_DEBUG is set

### DIFF
--- a/checkrt.c
+++ b/checkrt.c
@@ -47,6 +47,7 @@
 
 char *optional = NULL;
 char *optional_ld_preload = NULL;
+int debug_flag = 0;
 
 void checkrt(char *usr_in_appdir)
 {
@@ -62,6 +63,8 @@ void checkrt(char *usr_in_appdir)
     char *gcc_bundle_lib = "./" GCCDIR "/libgcc_s.so.1";
     const char *format = "tr '\\0' '\\n' < '%s' | grep -e '%s' | tail -n1";
 
+    debug_flag = getenv("APPIMAGE_CHECKRT_DEBUG") ? 1 : 0;
+
     if (access(stdcxx_bundle_lib, F_OK) == 0) {
         f = popen("ldconfig -p | grep 'libstdc++.so.6 (" LIBC6_ARCH ")' | awk 'NR==1{print $NF}'", "r");
         ret = fscanf(f, "%s", stdcxx_sys_lib); (void)ret;
@@ -72,8 +75,8 @@ void checkrt(char *usr_in_appdir)
             SCANLIB(stdcxx_bundle_lib, stdcxx_bundle_sym, "^GLIBCXX_3\\.4");
             stdcxx_sys_ver = atoi(stdcxx_sys_sym+12);
             stdcxx_bundle_ver = atoi(stdcxx_bundle_sym+12);
-            //printf("%s ==> %s (%d)\n", stdcxx_sys_lib, stdcxx_sys_sym, stdcxx_sys_ver);
-            //printf("%s ==> %s (%d)\n\n", stdcxx_bundle_lib, stdcxx_bundle_sym, stdcxx_bundle_ver);
+            DEBUG("%s ==> %s (%d)\n", stdcxx_sys_lib, stdcxx_sys_sym, stdcxx_sys_ver);
+            DEBUG("%s ==> %s (%d)\n\n", stdcxx_bundle_lib, stdcxx_bundle_sym, stdcxx_bundle_ver);
         }
     }
 
@@ -87,8 +90,8 @@ void checkrt(char *usr_in_appdir)
             SCANLIB(gcc_bundle_lib, gcc_bundle_sym, "^GCC_[0-9]\\.[0-9]");
             gcc_sys_ver = atoi(gcc_sys_sym+4) * 100 + atoi(gcc_sys_sym+6) * 10 + atoi(gcc_sys_sym+8);
             gcc_bundle_ver = atoi(gcc_bundle_sym+4) * 100 + atoi(gcc_bundle_sym+6) * 10 + atoi(gcc_bundle_sym+8);
-            //printf("%s ==> %s (%d)\n", gcc_sys_lib, gcc_sys_sym, gcc_sys_ver);
-            //printf("%s ==> %s (%d)\n\n", gcc_bundle_lib, gcc_bundle_sym, gcc_bundle_ver);
+            DEBUG("%s ==> %s (%d)\n", gcc_sys_lib, gcc_sys_sym, gcc_sys_ver);
+            DEBUG("%s ==> %s (%d)\n\n", gcc_bundle_lib, gcc_bundle_sym, gcc_bundle_ver);
         }
     }
 
@@ -121,6 +124,6 @@ void checkrt(char *usr_in_appdir)
         sprintf(optional, "%s", "");
     }
 
-    //printf("optional: %s\noptional_ld_preload: %s\n", optional, optional_ld_preload);
+    DEBUG("optional: %s\noptional_ld_preload: %s\n", optional, optional_ld_preload);
 }
 

--- a/checkrt.h
+++ b/checkrt.h
@@ -1,3 +1,9 @@
 extern char *optional;
 extern char *optional_ld_preload;
 extern void checkrt(char *usr_in_appdir);
+extern int debug_flag;
+
+#define DEBUG(...) do { \
+    if (debug_flag) \
+        printf(__VA_ARGS__); \
+} while (0)

--- a/exec.c
+++ b/exec.c
@@ -42,6 +42,8 @@ variable (e.g. "PATH"):
 
 #define _GNU_SOURCE
 
+#include "checkrt.h"
+
 #include <unistd.h>
 #include <dlfcn.h>
 #include <stdio.h>
@@ -281,7 +283,7 @@ int execve(const char* filename, char* const argv[], char* const envp[]) {
     old_execve = dlsym(RTLD_NEXT, "execve");
     int ret = old_execve(filename, argv, new_envp);
     stringlist_free(new_envp);
-    //printf(">>> custom execve()!\n");
+    DEBUG(">>> custom execve()!\n");
     return ret;
 }
 
@@ -290,7 +292,7 @@ int execv(const char* filename, char* const argv[]) {
     old_execve = dlsym(RTLD_NEXT, "execve");
     int ret = old_execve(filename, argv, new_envp);
     stringlist_free(new_envp);
-    //printf(">>> custom execv()!\n");
+    DEBUG(">>> custom execv()!\n");
     return ret;
 }
 
@@ -300,7 +302,7 @@ int execvpe(const char* filename, char* const argv[], char* const envp[]) {
     old_execvpe = dlsym(RTLD_NEXT, "execvpe");
     int ret = old_execvpe(filename, argv, new_envp);
     stringlist_free(new_envp);
-    //printf(">>> custom execvpe()!\n");
+    DEBUG(">>> custom execvpe()!\n");
     return ret;
 }
 
@@ -310,6 +312,6 @@ int execvp(const char* filename, char* const argv[]) {
     old_execvpe = dlsym(RTLD_NEXT, "execvpe");
     int ret = old_execvpe(filename, argv, new_envp);
     stringlist_free(new_envp);
-    //printf(">>> custom execvp()!\n");
+    DEBUG(">>> custom execvp()!\n");
     return ret;
 }


### PR DESCRIPTION
This is simple PR to get debug logs to ease debugging logs as commented in https://github.com/darealshinji/AppImageKit-checkrt/issues/4#issuecomment-355734739.

The idea is simple: setting `APPIMAGE_CHECKRT_DEBUG` environment variable will enable debug logs to help to figure out issues.