### PR TITLE
Move DEBUG macro to own header to be a standalone helper

### DIFF
--- a/checkrt.c
+++ b/checkrt.c
@@ -18,6 +18,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+#include "debug.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -47,7 +48,6 @@
 
 char *optional = NULL;
 char *optional_ld_preload = NULL;
-int debug_flag = 0;
 
 void checkrt(char *usr_in_appdir)
 {
@@ -62,8 +62,6 @@ void checkrt(char *usr_in_appdir)
     char *stdcxx_bundle_lib = "./" CXXDIR "/libstdc++.so.6";
     char *gcc_bundle_lib = "./" GCCDIR "/libgcc_s.so.1";
     const char *format = "tr '\\0' '\\n' < '%s' | grep -e '%s' | tail -n1";
-
-    debug_flag = getenv("APPIMAGE_CHECKRT_DEBUG") ? 1 : 0;
 
     if (access(stdcxx_bundle_lib, F_OK) == 0) {
         f = popen("ldconfig -p | grep 'libstdc++.so.6 (" LIBC6_ARCH ")' | awk 'NR==1{print $NF}'", "r");

--- a/checkrt.h
+++ b/checkrt.h
@@ -1,9 +1,8 @@
+#ifndef CHEKRT_H
+#define CHECKRT_H
+
 extern char *optional;
 extern char *optional_ld_preload;
 extern void checkrt(char *usr_in_appdir);
-extern int debug_flag;
 
-#define DEBUG(...) do { \
-    if (debug_flag) \
-        printf(__VA_ARGS__); \
-} while (0)
+#endif

--- a/debug.h
+++ b/debug.h
@@ -1,0 +1,11 @@
+#ifndef DEBUG_H
+#define DEBUG_H
+
+#include <stdlib.h>
+
+#define DEBUG(...) do { \
+    if (getenv("APPIMAGE_CHECKRT_DEBUG")) \
+        printf(__VA_ARGS__); \
+} while (0)
+
+#endif // DEBUG_H

--- a/exec.c
+++ b/exec.c
@@ -42,7 +42,7 @@ variable (e.g. "PATH"):
 
 #define _GNU_SOURCE
 
-#include "checkrt.h"
+#include "debug.h"
 
 #include <unistd.h>
 #include <dlfcn.h>


### PR DESCRIPTION
I made a mistake in the previous PR https://github.com/darealshinji/AppImageKit-checkrt/pull/6 because I thought that `exec.o` was linked along `checkrt.o` to create `exec.so`. That is not the case, as @probono tested at https://github.com/darealshinji/AppImageKit-checkrt/issues/4#issuecomment-355747604 (`audacity: symbol lookup error: /home/me/squashfs-root/usr/optional/exec.so: undefined symbol: debug_flag`).

Surprisingly, I didn't get that warning from the dynamic linker when I tested it with my own AppImage. In any case, this should fix the issue since the debug header is a standalone header that any translation unit may use without any dependence.



  
  