### PR TITLE
Prepend optional directories to LD_LIBRARY_PATH instead of PATH

### DIFF
--- a/AppRun.c.patch
+++ b/AppRun.c.patch
@@ -1,6 +1,6 @@
 --- a/AppRun.c
 +++ b/AppRun.c
-@@ -164,12 +164,16 @@
+@@ -164,6 +164,10 @@
      char *old_env;
      size_t length;
      const char *format;
@@ -11,18 +11,20 @@
  
      /* https://docs.python.org/2/using/cmdline.html#envvar-PYTHONHOME */
      SET_NEW_ENV(new_pythonhome, appdir_s, "PYTHONHOME=%s/usr/", appdir);
- 
-     old_env = getenv("PATH") ?: "";
--    SET_NEW_ENV(new_path, appdir_s*5 + strlen(old_env), "PATH=%s/usr/bin/:%s/usr/sbin/:%s/usr/games/:%s/bin/:%s/sbin/:%s", appdir, appdir, appdir, appdir, appdir, old_env);
-+    SET_NEW_ENV(new_path, appdir_s*5 + strlen(old_env), "PATH=%s%s/usr/bin/:%s/usr/sbin/:%s/usr/games/:%s/bin/:%s/sbin/:%s", optional, appdir, appdir, appdir, appdir, appdir, old_env);
+@@ -172,7 +176,7 @@
+     SET_NEW_ENV(new_path, appdir_s*5 + strlen(old_env), "PATH=%s/usr/bin/:%s/usr/sbin/:%s/usr/games/:%s/bin/:%s/sbin/:%s", appdir, appdir, appdir, appdir, appdir, old_env);
  
      old_env = getenv("LD_LIBRARY_PATH") ?: "";
-     SET_NEW_ENV(new_ld_library_path, appdir_s*10 + strlen(old_env), "LD_LIBRARY_PATH=%s/usr/lib/:%s/usr/lib/i386-linux-gnu/:%s/usr/lib/x86_64-linux-gnu/:%s/usr/lib32/:%s/usr/lib64/:%s/lib/:%s/lib/i386-linux-gnu/:%s/lib/x86_64-linux-gnu/:%s/lib32/:%s/lib64/:%s", appdir, appdir, appdir, appdir, appdir, appdir, appdir, appdir, appdir, appdir, old_env);
+-    SET_NEW_ENV(new_ld_library_path, appdir_s*10 + strlen(old_env), "LD_LIBRARY_PATH=%s/usr/lib/:%s/usr/lib/i386-linux-gnu/:%s/usr/lib/x86_64-linux-gnu/:%s/usr/lib32/:%s/usr/lib64/:%s/lib/:%s/lib/i386-linux-gnu/:%s/lib/x86_64-linux-gnu/:%s/lib32/:%s/lib64/:%s", appdir, appdir, appdir, appdir, appdir, appdir, appdir, appdir, appdir, appdir, old_env);
++    SET_NEW_ENV(new_ld_library_path, appdir_s*10 + strlen(old_env), "LD_LIBRARY_PATH=%s%s/usr/lib/:%s/usr/lib/i386-linux-gnu/:%s/usr/lib/x86_64-linux-gnu/:%s/usr/lib32/:%s/usr/lib64/:%s/lib/:%s/lib/i386-linux-gnu/:%s/lib/x86_64-linux-gnu/:%s/lib32/:%s/lib64/:%s", optional_ld_library_path, appdir, appdir, appdir, appdir, appdir, appdir, appdir, appdir, appdir, appdir, old_env);
+
+     old_env = getenv("PYTHONPATH") ?: "";
+     SET_NEW_ENV(new_pythonpath, appdir_s + strlen(old_env), "PYTHONPATH=%s/usr/share/pyshared/:%s", appdir, old_env);
 @@ -201,6 +205,9 @@
      if (ret == -1)
          die("Error executing '%s': %s\n", exe, strerror(error));
- 
-+    free(optional);
+
++    free(optional_ld_library_path);
 +    if (optional_ld_preload)
 +        free(optional_ld_preload);
      free(line);

--- a/checkrt.c
+++ b/checkrt.c
@@ -46,7 +46,7 @@
 #define GCCDIR   "optional/libgcc"
 #define EXEC_SO  "optional/exec.so"
 
-char *optional = NULL;
+char *optional_ld_library_path = NULL;
 char *optional_ld_preload = NULL;
 
 void checkrt(char *usr_in_appdir)
@@ -111,19 +111,19 @@ void checkrt(char *usr_in_appdir)
     }
 
     if (bundle_cxx == 1 && bundle_gcc == 0) {
-        optional = malloc(strlen(CXXDIR) + 3 + len);
-        sprintf(optional, "%s/" CXXDIR ":", usr_in_appdir);
+        optional_ld_library_path = malloc(strlen(CXXDIR) + 3 + len);
+        sprintf(optional_ld_library_path, "%s/" CXXDIR ":", usr_in_appdir);
     } else if (bundle_cxx == 0 && bundle_gcc == 1) {
-        optional = malloc(strlen(GCCDIR) + 3 + len);
-        sprintf(optional, "%s/" GCCDIR ":", usr_in_appdir);
+        optional_ld_library_path = malloc(strlen(GCCDIR) + 3 + len);
+        sprintf(optional_ld_library_path, "%s/" GCCDIR ":", usr_in_appdir);
     } else if (bundle_cxx == 1 && bundle_gcc == 1) {
-        optional = malloc(strlen(GCCDIR) + strlen(CXXDIR) + 5 + len*2);
-        sprintf(optional, "%s/" GCCDIR ":%s/" CXXDIR ":", usr_in_appdir, usr_in_appdir);
+        optional_ld_library_path = malloc(strlen(GCCDIR) + strlen(CXXDIR) + 5 + len*2);
+        sprintf(optional_ld_library_path, "%s/" GCCDIR ":%s/" CXXDIR ":", usr_in_appdir, usr_in_appdir);
     } else {
-        optional = malloc(2);
-        sprintf(optional, "%s", "");
+        optional_ld_library_path = malloc(2);
+        sprintf(optional_ld_library_path, "%s", "");
     }
 
-    DEBUG("optional: %s\noptional_ld_preload: %s\n", optional, optional_ld_preload);
+    DEBUG("optional_ld_library_path: %s\noptional_ld_preload: %s\n", optional_ld_library_path, optional_ld_preload);
 }
 

--- a/checkrt.h
+++ b/checkrt.h
@@ -1,7 +1,7 @@
 #ifndef CHEKRT_H
 #define CHECKRT_H
 
-extern char *optional;
+extern char *optional_ld_library_path;
 extern char *optional_ld_preload;
 extern void checkrt(char *usr_in_appdir);
 

--- a/debug.h
+++ b/debug.h
@@ -5,7 +5,7 @@
 
 #define DEBUG(...) do { \
     if (getenv("APPIMAGE_CHECKRT_DEBUG")) \
-        printf(__VA_ARGS__); \
+        printf("APPIMAGE_CHECKRT>> " __VA_ARGS__); \
 } while (0)
 
 #endif // DEBUG_H


### PR DESCRIPTION
This PR is related to https://github.com/darealshinji/AppImageKit-checkrt/issues/4. After reading https://github.com/darealshinji/AppImageKit-checkrt/issues/4#issuecomment-355768424 and taking a look at the code, I found weird that we were appending `optional/[libstdc++|libgcc]` to `PATH` env variable at https://github.com/darealshinji/AppImageKit-checkrt/blob/master/AppRun.c.patch#L16-L17.

I have always used `LD_LIBRARY_PATH` for what checkrt intends to do. According to LD documentation http://man7.org/linux/man-pages/man8/ld.so.8.html, this env variable is the one that is used first on the list.

Apart from that, I have simply refactored `optional` to `optional_ld_library_path` for consistency and have added `APPIMAGE_CHECKRT>> ` to debug log for clarification.

