### PR TITLE
Fix insufficient buffer for LD_LIBRARY_PATH

### DIFF
--- a/AppRun.c.patch
+++ b/AppRun.c.patch
@@ -16,7 +16,7 @@
  
      old_env = getenv("LD_LIBRARY_PATH") ?: "";
 -    SET_NEW_ENV(new_ld_library_path, appdir_s*10 + strlen(old_env), "LD_LIBRARY_PATH=%s/usr/lib/:%s/usr/lib/i386-linux-gnu/:%s/usr/lib/x86_64-linux-gnu/:%s/usr/lib32/:%s/usr/lib64/:%s/lib/:%s/lib/i386-linux-gnu/:%s/lib/x86_64-linux-gnu/:%s/lib32/:%s/lib64/:%s", appdir, appdir, appdir, appdir, appdir, appdir, appdir, appdir, appdir, appdir, old_env);
-+    SET_NEW_ENV(new_ld_library_path, appdir_s*10 + strlen(old_env), "LD_LIBRARY_PATH=%s%s/usr/lib/:%s/usr/lib/i386-linux-gnu/:%s/usr/lib/x86_64-linux-gnu/:%s/usr/lib32/:%s/usr/lib64/:%s/lib/:%s/lib/i386-linux-gnu/:%s/lib/x86_64-linux-gnu/:%s/lib32/:%s/lib64/:%s", optional_ld_library_path, appdir, appdir, appdir, appdir, appdir, appdir, appdir, appdir, appdir, appdir, old_env);
++    SET_NEW_ENV(new_ld_library_path, strlen(optional_ld_library_path) + appdir_s*10 + strlen(old_env), "LD_LIBRARY_PATH=%s%s/usr/lib/:%s/usr/lib/i386-linux-gnu/:%s/usr/lib/x86_64-linux-gnu/:%s/usr/lib32/:%s/usr/lib64/:%s/lib/:%s/lib/i386-linux-gnu/:%s/lib/x86_64-linux-gnu/:%s/lib32/:%s/lib64/:%s", optional_ld_library_path, appdir, appdir, appdir, appdir, appdir, appdir, appdir, appdir, appdir, appdir, old_env);
 
      old_env = getenv("PYTHONPATH") ?: "";
      SET_NEW_ENV(new_pythonpath, appdir_s + strlen(old_env), "PYTHONPATH=%s/usr/share/pyshared/:%s", appdir, old_env);

--- a/exec.c
+++ b/exec.c
@@ -283,7 +283,7 @@ int execve(const char* filename, char* const argv[], char* const envp[]) {
     old_execve = dlsym(RTLD_NEXT, "execve");
     int ret = old_execve(filename, argv, new_envp);
     stringlist_free(new_envp);
-    DEBUG(">>> custom execve()!\n");
+    DEBUG("custom execve()!\n");
     return ret;
 }
 
@@ -292,7 +292,7 @@ int execv(const char* filename, char* const argv[]) {
     old_execve = dlsym(RTLD_NEXT, "execve");
     int ret = old_execve(filename, argv, new_envp);
     stringlist_free(new_envp);
-    DEBUG(">>> custom execv()!\n");
+    DEBUG("custom execv()!\n");
     return ret;
 }
 
@@ -302,7 +302,7 @@ int execvpe(const char* filename, char* const argv[], char* const envp[]) {
     old_execvpe = dlsym(RTLD_NEXT, "execvpe");
     int ret = old_execvpe(filename, argv, new_envp);
     stringlist_free(new_envp);
-    DEBUG(">>> custom execvpe()!\n");
+    DEBUG("custom execvpe()!\n");
     return ret;
 }
 
@@ -312,6 +312,6 @@ int execvp(const char* filename, char* const argv[]) {
     old_execvpe = dlsym(RTLD_NEXT, "execvpe");
     int ret = old_execvpe(filename, argv, new_envp);
     stringlist_free(new_envp);
-    DEBUG(">>> custom execvp()!\n");
+    DEBUG("custom execvp()!\n");
     return ret;
 }


### PR DESCRIPTION
I didn't notice when moving the logic from `PATH` to `LD_LIBRARY_PATH` that there was another issue. We also need to take the `optional` length into account to properly allocate the size of the buffer.

Apart from that, I removed the extra `>>>` from exec.so since we are already adding two of them in `DEBUG` anyways and seems redundant.