### PR TITLE
checkrt, AppRun.sh: Sort version symbols when scanning

### DIFF
--- a/AppRun.sh
+++ b/AppRun.sh
@@ -19,8 +19,8 @@ cd "usr"
 
 if [ -e "./optional/libstdc++/libstdc++.so.6" ]; then
   lib="$(PATH="/sbin:$PATH" ldconfig -p | grep "libstdc++\.so\.6 ($libc6arch)" | awk 'NR==1{print $NF}')"
-  sym_sys=$(tr '\0' '\n' < "$lib" | grep -e '^GLIBCXX_3\.4' | tail -n1)
-  sym_app=$(tr '\0' '\n' < "./optional/libstdc++/libstdc++.so.6" | grep -e '^GLIBCXX_3\.4' | tail -n1)
+  sym_sys=$(tr '\0' '\n' < "$lib" | grep -e '^GLIBCXX_3\.4' | sort -V | tail -n1)
+  sym_app=$(tr '\0' '\n' < "./optional/libstdc++/libstdc++.so.6" | grep -e '^GLIBCXX_3\.4' | sort -V | tail -n1)
   if [ "$(printf "${sym_sys}\n${sym_app}"| sort -V | tail -1)" != "$sym_sys" ]; then
     cxxpath="./optional/libstdc++:"
   fi
@@ -28,8 +28,8 @@ fi
 
 if [ -e "./optional/libgcc/libgcc_s.so.1" ]; then
   lib="$(PATH="/sbin:$PATH" ldconfig -p | grep "libgcc_s\.so\.1 ($libc6arch)" | awk 'NR==1{print $NF}')"
-  sym_sys=$(tr '\0' '\n' < "$lib" | grep -e '^GCC_[0-9]\\.[0-9]' | tail -n1)
-  sym_app=$(tr '\0' '\n' < "./optional/libgcc/libgcc_s.so.1" | grep -e '^GCC_[0-9]\\.[0-9]' | tail -n1)
+  sym_sys=$(tr '\0' '\n' < "$lib" | grep -e '^GCC_[0-9]\\.[0-9]' | sort -V | tail -n1)
+  sym_app=$(tr '\0' '\n' < "./optional/libgcc/libgcc_s.so.1" | grep -e '^GCC_[0-9]\\.[0-9]' | sort -V | tail -n1)
   if [ "$(printf "${sym_sys}\n${sym_app}"| sort -V | tail -1)" != "$sym_sys" ]; then
     gccpath="./optional/libgcc:"
   fi

--- a/checkrt.c
+++ b/checkrt.c
@@ -61,7 +61,7 @@ void checkrt(char *usr_in_appdir)
 
     char *stdcxx_bundle_lib = "./" CXXDIR "/libstdc++.so.6";
     char *gcc_bundle_lib = "./" GCCDIR "/libgcc_s.so.1";
-    const char *format = "tr '\\0' '\\n' < '%s' | grep -e '%s' | tail -n1";
+    const char *format = "tr '\\0' '\\n' < '%s' | grep -e '%s' | sort -V | tail -n1";
 
     if (access(stdcxx_bundle_lib, F_OK) == 0) {
         f = popen("PATH=\"/sbin:$PATH\" ldconfig -p | grep 'libstdc++.so.6 (" LIBC6_ARCH ")' | awk 'NR==1{print $NF}'", "r");


### PR DESCRIPTION
Arch Linux's latest x86_64 libstdc++ library does not sort the GLIBCXX symbols. The final relevant symbol in the library is GLIBCXX_3.4.26, when the highest version number is actually 3.4.30. In our application, the included libstdc++ has 3.4.29, which is newer than what the scan finds but older than what host libraries need, i.e. in Mesa. Thus AppRun will run the optional libstdc++ and host libraries will fail to load.

Insert a `sort -V` call to ensure the scan will use the latest version found in the library.

